### PR TITLE
Initialize decryptedImporter

### DIFF
--- a/src/renderer/components/MainPage/Importers/Importer.vue
+++ b/src/renderer/components/MainPage/Importers/Importer.vue
@@ -67,6 +67,7 @@ export default {
       success: null,
       lastMessage: null,
       showBrowser: false,
+      decryptedImporter: null,
     };
   },
   computed: {


### PR DESCRIPTION
fixes #41 

The `decryptedImporter` didn't create at render time, but it created when `created` get the `promise` back.